### PR TITLE
Fix gameName in diceBot.json

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -53,7 +53,7 @@ task extract_info_list: [:patch] do
 
     {
       gameType: gameType,
-      gameName: diceBot.id,
+      gameName: diceBot.gameName,
       prefixes: diceBot.prefixes.flatten,
       info: diceBot.help_message
     }

--- a/Rakefile
+++ b/Rakefile
@@ -53,7 +53,7 @@ task extract_info_list: [:patch] do
 
     {
       gameType: gameType,
-      gameName: diceBot.gameName,
+      gameName: diceBot.name,
       prefixes: diceBot.prefixes.flatten,
       info: diceBot.help_message
     }


### PR DESCRIPTION
`BCDice.infoList` の内容がおそらく意図せず変わってしまっていたため修正してみました。
手元では build が通るところまで確認しています。