### PR TITLE
Use DiceBot#sort_key

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,11 +54,14 @@ task extract_info_list: [:patch] do
     {
       gameType: gameType,
       gameName: diceBot.name,
+      sortKey: diceBot.sort_key,
       prefixes: diceBot.prefixes.flatten,
       info: diceBot.help_message
     }
   end
   print "\n"
+
+  infoList.sort_by! { |info| info[:sortKey] }
 
   json = JSON.pretty_generate(
     infoList: infoList

--- a/src/BCDice.ts
+++ b/src/BCDice.ts
@@ -8,6 +8,7 @@ declare const Opal: any;
 export interface Info {
   gameType: string;
   gameName: string;
+  sortKey: string;
   prefixes: string;
   info: string;
 }


### PR DESCRIPTION
 BCDice Ver2.04.00で追加された `DiceBot#sort_key` ダイスボット情報に含めるようにし、それを使ってダイスボットをソートするようにします。

`DiceBot#sort_key` はTRPGシステム名の五十音順に並べられるようにヨミが設定されている。この情報を使うことで、先頭文字ごとに区切ったり、利用者が推測しやすい準備に並べ替えたりすることができる。