### PR TITLE
Update BCDice to 2.07.01

### DIFF
--- a/patch.diff
+++ b/patch.diff
@@ -1,8 +1,8 @@
 diff --git a/src/bcdiceCore.rb b/src/bcdiceCore.rb
-index 23286c3..661a98b 100755
+index 0b0852e..e9db745 100755
 --- a/src/bcdiceCore.rb
 +++ b/src/bcdiceCore.rb
-@@ -891,7 +891,7 @@ class BCDice
+@@ -553,7 +553,7 @@ class BCDice
      string, _secret, _count, swapMarker = getD66Infos(dice)
      unless  string.nil?
        value = getD66ValueByMarker(swapMarker)
@@ -12,7 +12,7 @@ index 23286c3..661a98b 100755
      end
  
 diff --git a/src/dice/add_dice/node.rb b/src/dice/add_dice/node.rb
-index 7ddc2b4..e9f0073 100644
+index 824d26e..9786c88 100644
 --- a/src/dice/add_dice/node.rb
 +++ b/src/dice/add_dice/node.rb
 @@ -231,7 +231,7 @@ class AddDice
@@ -24,8 +24,30 @@ index 7ddc2b4..e9f0073 100644
        end
      end
  
+diff --git a/src/diceBot/ChaosFlare.rb b/src/diceBot/ChaosFlare.rb
+index 099d76e..d37ac84 100644
+--- a/src/diceBot/ChaosFlare.rb
++++ b/src/diceBot/ChaosFlare.rb
+@@ -98,7 +98,7 @@ INFO_MESSAGE_TEXT
+         return "因果表(#{num}) ＞ #{FATE_TABLE[num][0]}"
+       end
+ 
+-      dice1 = num / 10
++      dice1 = num.div(10)
+       dice2 = num % 10
+       if !(1..6).include?(dice1) || !(1..6).include?(dice2)
+         return nil
+@@ -109,7 +109,7 @@ INFO_MESSAGE_TEXT
+     end
+ 
+     index1 = dice1
+-    index2 = (dice2 / 2) - 1
++    index2 = dice2.div(2) - 1
+     return "因果表(#{dice1}#{dice2}) ＞ #{FATE_TABLE[index1][index2]}"
+   end
+ 
 diff --git a/src/diceBot/Chill3.rb b/src/diceBot/Chill3.rb
-index 273d65b..06d61fd 100644
+index 78ebaaf..ac2106a 100644
 --- a/src/diceBot/Chill3.rb
 +++ b/src/diceBot/Chill3.rb
 @@ -22,7 +22,7 @@ INFO_MESSAGE_TEXT
@@ -38,19 +60,10 @@ index 273d65b..06d61fd 100644
  
      if tens == ones
 diff --git a/src/diceBot/Cthulhu7th.rb b/src/diceBot/Cthulhu7th.rb
-index 1e85d2c..6262c58 100644
+index faa03f1..fcc55d3 100644
 --- a/src/diceBot/Cthulhu7th.rb
 +++ b/src/diceBot/Cthulhu7th.rb
-@@ -421,7 +421,7 @@ INFO_MESSAGE_TEXT
-   end
- 
-   def getSetOfBullet(diff)
--    bullet_set_count = diff / 10
-+    bullet_set_count = diff.div(10)
- 
-     if (diff >= 1) && (diff < 30)
-       bullet_set_count = 3 # 技能値が29以下での最低値保障処理
-@@ -431,7 +431,7 @@ INFO_MESSAGE_TEXT
+@@ -456,7 +456,7 @@ INFO_MESSAGE_TEXT
    end
  
    def getHitBulletCountBase(diff, bullet_set_count)
@@ -117,10 +130,10 @@ index b0e000c..1db0abe 100644
        sorted_dice_values = dice_values.sort
        roll_result = calculate_roll_result(sorted_dice_values)
 diff --git a/src/diceBot/DiceBot.rb b/src/diceBot/DiceBot.rb
-index 8aed5ec..e2da3d6 100644
+index dff2d51..5e19ae7 100644
 --- a/src/diceBot/DiceBot.rb
 +++ b/src/diceBot/DiceBot.rb
-@@ -529,13 +529,13 @@ class DiceBot
+@@ -517,13 +517,13 @@ class DiceBot
          item, value = get_table_by_d66(table)
          value = value.to_i
          output = item[1]
@@ -317,7 +330,7 @@ index ab4b100..8519b95 100644
      dice_total, = roll(1, 12)
      debug('dice_total, target_total, success_degree = ', dice_total, target_total, success_degree)
 diff --git a/src/diceBot/LogHorizon.rb b/src/diceBot/LogHorizon.rb
-index 105b932..bb05cec 100644
+index 7ecdfa6..0e612e4 100644
 --- a/src/diceBot/LogHorizon.rb
 +++ b/src/diceBot/LogHorizon.rb
 @@ -477,7 +477,7 @@ MESSAGETEXT
@@ -390,7 +403,7 @@ index 26d9575..b8a3706 100644
  
      if isValidDice(dice1, dice2)
 diff --git a/src/diceBot/SRS.rb b/src/diceBot/SRS.rb
-index 1e6f8a6..687ec24 100644
+index 6429945..757c8fc 100644
 --- a/src/diceBot/SRS.rb
 +++ b/src/diceBot/SRS.rb
 @@ -81,15 +81,15 @@ HELP_MESSAGE
@@ -414,7 +427,7 @@ index 1e6f8a6..687ec24 100644
  
        prepare_help_msg_for_aliases_for_srs_roll(aliases_upcase)
 diff --git a/src/diceBot/ShinMegamiTenseiKakuseihen.rb b/src/diceBot/ShinMegamiTenseiKakuseihen.rb
-index 95cd4f6..190677d 100644
+index 516b36c..6e2d811 100644
 --- a/src/diceBot/ShinMegamiTenseiKakuseihen.rb
 +++ b/src/diceBot/ShinMegamiTenseiKakuseihen.rb
 @@ -43,7 +43,7 @@ INFO_MESSAGE_TEXT
@@ -439,87 +452,19 @@ index 7440c39..1b85f59 100644
      movePoint = movePointBase + bonus
      debug("移動エリア数", movePoint)
  
-diff --git a/src/diceBot/TorgEternity.rb b/src/diceBot/TorgEternity.rb
-index da1fcc5..fe04d55 100644
---- a/src/diceBot/TorgEternity.rb
-+++ b/src/diceBot/TorgEternity.rb
-@@ -99,12 +99,11 @@ INFO_MESSAGE_TEXT
-   def getRolld20DiceCommandResult(command)
-     debug("Torg Eternity Dice Roll Command ? ", command)
-     m = /(^|\s)(S)?(TE)/i =~ command
--    debug(Regexp.last_match(2))
--    secret = !Regexp.last_match(2).nil?
-     unless m
-       debug("None")
-       return nil
-     end
-+    secret = !Regexp.last_match(2).nil?
-     debug("Yes!")
-     skilled, unskilled, dice_str, mishap = torg_eternity_dice(false, true)
-     if mishap == 1
-@@ -126,12 +125,11 @@ INFO_MESSAGE_TEXT
-   def getUpRollDiceCommandResult(command)
-     debug("Torg Eternity Dice Roll ( UP ) Command ? ", command)
-     m = /(^|\s)(S)?(UP)/i =~ command
--    debug(Regexp.last_match(2))
--    secret = !Regexp.last_match(2).nil?
-     unless m
-       debug("None")
-       return nil
-     end
-+    secret = !Regexp.last_match(2).nil?
-     debug("Yes!")
-     skilled1, unskilled1, dice_str1, mishap = torg_eternity_dice(false, true)
-     if mishap == 1
-@@ -156,13 +154,11 @@ INFO_MESSAGE_TEXT
-   def getPossibilityRollDiceCommandResult(command)
-     debug("Torg Eternity Possibility Roll Command ? ", command)
-     m = /(^|\s)(S)?(POS)((\d+)(\+\d+)?)/i =~ command
--    debug(Regexp.last_match(2))
--    debug(Regexp.last_match(4))
--    secret = !Regexp.last_match(2).nil?
-     unless m
-       debug("None")
-       return nil
-     end
-+    secret = !Regexp.last_match(2).nil?
-     debug("Yes!")
-     output_modifier = parren_killer("(0#{Regexp.last_match(4)})").to_i
-     skilled, unskilled, dice_str, = torg_eternity_dice(true, false)
-@@ -183,8 +179,6 @@ INFO_MESSAGE_TEXT
-   def getBonusDamageDiceCommandResult(command)
-     debug("TorgEternity Bonus Damage Roll Command ? ", command)
-     m = /(\d+)(BD)(([\+\-]\d+)*)/i.match(command)
--    debug(Regexp.last_match(1))
--    debug(Regexp.last_match(3))
-     unless m
-       debug("None")
-       return nil
-@@ -206,7 +200,6 @@ INFO_MESSAGE_TEXT
-   def getSuccessLevelDiceCommandResult(command)
-     debug("TorgEternity Success Level Table Command ? ", command)
-     m = /(RT|Result)(\d+([\+\-]\d+)*)/i.match(command)
--    debug(Regexp.last_match(2))
-     unless m
-       debug("None")
-       return nil
-@@ -228,7 +221,6 @@ INFO_MESSAGE_TEXT
-   def getDamageResultDiceCommandResult(command)
-     debug("TorgEternity Damage Result Table Command ? ", command)
-     m = /(DT|Damage)(\d+([\+\-]\d+)*)/i.match(command)
--    debug(Regexp.last_match(2))
-     unless m
-       debug("None")
-       return nil
-@@ -246,8 +238,6 @@ INFO_MESSAGE_TEXT
-   def getRollBonusDiceCommandResult(command)
-     debug("TorgEternity Roll Bonus Table Command ? ", command)
-     m = /(BT|Bonus)(\d+)(([\+\-]\d+)*)/i.match(command)
--    debug(Regexp.last_match(2))
--    debug(Regexp.last_match(3))
-     unless m
-       debug("None")
-       return nil
+diff --git a/src/diceBot/VampireTheMasquerade5th.rb b/src/diceBot/VampireTheMasquerade5th.rb
+index d8ac7e7..5fe6168 100644
+--- a/src/diceBot/VampireTheMasquerade5th.rb
++++ b/src/diceBot/VampireTheMasquerade5th.rb
+@@ -93,7 +93,7 @@ MESSAGETEXT
+ 
+   def getCriticalSuccess(tenDice)
+     # 10の目が2個毎に追加2成功
+-    return ((tenDice / 2) * 2)
++    return tenDice.div(2) * 2
+   end
+ 
+   def makeDiceRoll(dicePool)
 diff --git a/src/diceBot/Warhammer.rb b/src/diceBot/Warhammer.rb
 index 5c39bc9..301c11f 100644
 --- a/src/diceBot/Warhammer.rb
@@ -549,16 +494,3 @@ index ad4cfa6..4876a07 100644
      end
    end
  
-diff --git a/src/diceBot/VampireTheMasquerade5th.rb b/src/diceBot/VampireTheMasquerade5th.rb
-index d8ac7e7..5fe6168 100644
---- a/src/diceBot/VampireTheMasquerade5th.rb
-+++ b/src/diceBot/VampireTheMasquerade5th.rb
-@@ -93,7 +93,7 @@ MESSAGETEXT
- 
-   def getCriticalSuccess(tenDice)
-     # 10の目が2個毎に追加2成功
--    return ((tenDice / 2) * 2)
-+    return tenDice.div(2) * 2
-   end
- 
-   def makeDiceRoll(dicePool)

--- a/src/DiceBotLoader.rb
+++ b/src/DiceBotLoader.rb
@@ -10,6 +10,7 @@ class DiceBotLoader
     debug('loadUnknownGame gameTitle', gameTitle)
 
     escapedGameTitle = gameTitle.gsub(%r{(\.\.|/|:|-)}, '_')
+    escapedGameTitle = 'DiceBot' if ['UpperDice'].include?(escapedGameTitle)
 
     begin
       Object.const_get(escapedGameTitle).new

--- a/tests/DiceBots.ts
+++ b/tests/DiceBots.ts
@@ -26,7 +26,7 @@ describe('DiceBots', () => {
 
     testDataList.forEach(([gameType, testData]) => {
       describe(gameType, () => {
-        if (!gameType.match(/^(TestDummy|PlotTest|None|dummyBot|Misonzai)$/)) {
+        if (!gameType.match(/^(TestDummy|PlotTest|None|dummyBot|Misonzai|UpperDice)$/)) {
           it('can import', async () => {
             await import(`../lib/diceBot/${gameType}`);
           });


### PR DESCRIPTION
BCDice Ver2.07.01のアップデートに追従します
https://github.com/bcdice/BCDice/releases/tag/v2.07.00
https://github.com/bcdice/BCDice/releases/tag/v2.07.01

テストファイルにDiceBotクラスを継承していないクラスの名前がついたファイルができてしまったので、テスト対象のクラスを探索するロジックに手を加えています。