### PR TITLE
新クトゥルフ神話TRPGの除算のパッチ漏れを修正

### DIFF
--- a/patch.diff
+++ b/patch.diff
@@ -1,5 +1,5 @@
 diff --git a/src/bcdiceCore.rb b/src/bcdiceCore.rb
-index 0b0852e..e9db745 100755
+index b7bb9f0..48d96f2 100755
 --- a/src/bcdiceCore.rb
 +++ b/src/bcdiceCore.rb
 @@ -553,7 +553,7 @@ class BCDice
@@ -60,9 +60,49 @@ index 78ebaaf..ac2106a 100644
  
      if tens == ones
 diff --git a/src/diceBot/Cthulhu7th.rb b/src/diceBot/Cthulhu7th.rb
-index faa03f1..fcc55d3 100644
+index faa03f1..1ace9d5 100644
 --- a/src/diceBot/Cthulhu7th.rb
 +++ b/src/diceBot/Cthulhu7th.rb
+@@ -164,8 +164,8 @@ INFO_MESSAGE_TEXT
+   def getCheckResultText(total, diff, fumbleable = false)
+     if total <= diff
+       return "クリティカル" if total == 1
+-      return "イクストリーム成功" if total <= (diff / 5)
+-      return "ハード成功" if total <= (diff / 2)
++      return "イクストリーム成功" if total <= diff.div(5)
++      return "ハード成功" if total <= diff.div(2)
+ 
+       return "レギュラー成功"
+     end
+@@ -223,7 +223,7 @@ INFO_MESSAGE_TEXT
+     broken_number = Regexp.last_match(3).to_i
+     bonus_dice_count = (Regexp.last_match(4) || 0).to_i
+     stop_count = (Regexp.last_match(5) || "").to_s.downcase
+-    bullet_set_count_cap = (Regexp.last_match(6) || diff / 10).to_i
++    bullet_set_count_cap = (Regexp.last_match(6) || diff.div(10)).to_i
+ 
+     output = ""
+ 
+@@ -235,8 +235,8 @@ INFO_MESSAGE_TEXT
+     end
+ 
+     # ボレーの上限の設定がおかしい場合の注意表示
+-    if (bullet_set_count_cap > diff / 10) && (diff > 39) && !Regexp.last_match(6).nil?
+-      bullet_set_count_cap = diff / 10
++    if (bullet_set_count_cap > diff.div(10)) && (diff > 39) && !Regexp.last_match(6).nil?
++      bullet_set_count_cap = diff.div(10)
+       output += "ボレーの弾丸の数の上限は\[技能値÷10（切り捨て）\]発なので、それより高い数を指定できません。ボレーの弾丸の数を#{bullet_set_count_cap}発に変更します。\n"
+     elsif (diff <= 39) && (bullet_set_count_cap > 3) && !Regexp.last_match(6).nil?
+       bullet_set_count_cap = 3
+@@ -442,7 +442,7 @@ INFO_MESSAGE_TEXT
+   end
+ 
+   def getSetOfBullet(diff, bullet_set_count_cap)
+-    bullet_set_count = diff / 10
++    bullet_set_count = diff.div(10)
+ 
+     if bullet_set_count_cap < bullet_set_count
+       bullet_set_count = bullet_set_count_cap
 @@ -456,7 +456,7 @@ INFO_MESSAGE_TEXT
    end
  


### PR DESCRIPTION
#10 の変更で除算のパッチ漏れがあったため修正。#10 の時点では `Cthulhu7th#getHitBulletCountBase` のみ適切にパッチされており、除算の結果が全てこのメソッドを通過するためテストで問題が発見できなかったのだと思われる。