### PR TITLE
型定義の書式修正

### DIFF
--- a/ts/bcdice/game_system_list.json.d.ts
+++ b/ts/bcdice/game_system_list.json.d.ts
@@ -5,5 +5,4 @@ export interface GameSystemInfo {
   sortKey: string;
 }
 
-declare const gameSystems: GameSystemInfo[];
-export { gameSystems };
+export declare const gameSystems: GameSystemInfo[];

--- a/ts/bcdice/game_system_list.json.d.ts
+++ b/ts/bcdice/game_system_list.json.d.ts
@@ -5,5 +5,5 @@ export interface GameSystemInfo {
   sortKey: string;
 }
 
-const gameSystems: GameSystemInfo[];
-export = { gameSystems };
+declare const gameSystems: GameSystemInfo[];
+export { gameSystems };


### PR DESCRIPTION
d.tsファイルの型定義の書式が誤っていたのを修正しました。

これにより、typescriptのプロジェクトでbcdice-jsを利用した時に、 tsconfig.jsonに `"skipLibCheck": true` の記述が不要となります。