### PR TITLE
変換後の各ダイスボットへの不要なi18nのrequireをなくす

### DIFF
--- a/patch.diff
+++ b/patch.diff
@@ -896,11 +896,13 @@ diff --git a/lib/bcdice/game_system/NinjaSlayer.rb b/lib/bcdice/game_system/Ninj
 diff --git a/lib/bcdice/game_system/RuinBreakers.rb b/lib/bcdice/game_system/RuinBreakers.rb
 --- a/lib/bcdice/game_system/RuinBreakers.rb
 +++ b/lib/bcdice/game_system/RuinBreakers.rb
-@@ -68,7 +68,7 @@ module BCDice
+@@ -67,8 +67,8 @@ module BCDice
+           return nil
          end
  
-         success_rate = ArithmeticEvaluator.eval(m[1])
+-        success_rate = ArithmeticEvaluator.eval(m[1])
 -        critical_border = m[4]&.to_i || [success_rate / 5, 1].max
++        success_rate = ArithmeticEvaluator.eval(m[1]).to_i
 +        critical_border = m[4]&.to_i || [(success_rate / 5).to_i, 1].max
          fumble_border = m[6]&.to_i || (success_rate < 100 ? 96 : 99)
  

--- a/patch.diff
+++ b/patch.diff
@@ -236,6 +236,17 @@ diff --git a/lib/bcdice/game_system/AFF2e.rb b/lib/bcdice/game_system/AFF2e.rb
            unless md
              return 'ダメージスロットは必須です。'
            end
+diff --git a/lib/bcdice/game_system/AlchemiaStruggle.rb b/lib/bcdice/game_system/AlchemiaStruggle.rb
+--- a/lib/bcdice/game_system/AlchemiaStruggle.rb
++++ b/lib/bcdice/game_system/AlchemiaStruggle.rb
+@@ -1,7 +1,5 @@
+ # frozen_string_literal: true
+ 
+-require "bcdice"
+-
+ module BCDice
+   module GameSystem
+     class AlchemiaStruggle < Base
 diff --git a/lib/bcdice/game_system/Amadeus.rb b/lib/bcdice/game_system/Amadeus.rb
 --- a/lib/bcdice/game_system/Amadeus.rb
 +++ b/lib/bcdice/game_system/Amadeus.rb
@@ -464,6 +475,17 @@ diff --git a/lib/bcdice/game_system/CthulhuTech.rb b/lib/bcdice/game_system/Cthu
  
        # 構文解析する
        # @param [String] command コマンド
+diff --git a/lib/bcdice/game_system/DesperateRun.rb b/lib/bcdice/game_system/DesperateRun.rb
+--- a/lib/bcdice/game_system/DesperateRun.rb
++++ b/lib/bcdice/game_system/DesperateRun.rb
+@@ -1,7 +1,5 @@
+ # frozen_string_literal: true
+ 
+-require "bcdice/base"
+-
+ module BCDice
+   module GameSystem
+     class DesperateRun < Base
 diff --git a/lib/bcdice/game_system/Dracurouge.rb b/lib/bcdice/game_system/Dracurouge.rb
 --- a/lib/bcdice/game_system/Dracurouge.rb
 +++ b/lib/bcdice/game_system/Dracurouge.rb
@@ -692,15 +714,15 @@ diff --git a/lib/bcdice/game_system/KemonoNoMori.rb b/lib/bcdice/game_system/Kem
 diff --git a/lib/bcdice/game_system/LogHorizon.rb b/lib/bcdice/game_system/LogHorizon.rb
 --- a/lib/bcdice/game_system/LogHorizon.rb
 +++ b/lib/bcdice/game_system/LogHorizon.rb
-@@ -1,6 +1,7 @@
+@@ -1,6 +1,6 @@
  # frozen_string_literal: true
  
- require "bcdice/base"
+-require "bcdice/base"
 +require "bcdice/arithmetic_evaluator"
  
  module BCDice
    module GameSystem
-@@ -358,13 +359,13 @@ module BCDice
+@@ -358,13 +358,13 @@ module BCDice
            if index <= 6
              translate("LogHorizon.TRS.below_lower_limit", value: 6) # 6以下の出目は未定義です
            elsif index <= 62
@@ -718,7 +740,7 @@ diff --git a/lib/bcdice/game_system/LogHorizon.rb b/lib/bcdice/game_system/LogHo
            else
              translate("LogHorizon.TRS.exceed_upper_limit", value: 88) # 88以上の出目は未定義です
            end
-@@ -379,7 +380,7 @@ module BCDice
+@@ -379,7 +379,7 @@ module BCDice
            if index <= 6
              translate("LogHorizon.TRS.below_lower_limit", value: 6)
            elsif index <= 53
@@ -727,7 +749,7 @@ diff --git a/lib/bcdice/game_system/LogHorizon.rb b/lib/bcdice/game_system/LogHo
            else
              translate("LogHorizon.TRS.exceed_upper_limit", value: 54)
            end
-@@ -394,13 +395,13 @@ module BCDice
+@@ -394,13 +394,13 @@ module BCDice
            if index <= 6
              translate("LogHorizon.TRS.below_lower_limit", value: 6)
            elsif index <= 162
@@ -745,7 +767,7 @@ diff --git a/lib/bcdice/game_system/LogHorizon.rb b/lib/bcdice/game_system/LogHo
            else
              translate("LogHorizon.TRS.exceed_upper_limit", value: 188)
            end
-@@ -509,7 +510,7 @@ module BCDice
+@@ -509,7 +509,7 @@ module BCDice
  
          table_name = translate("LogHorizon.ESTL.name")
          table = translate("LogHorizon.ESTL.items")
@@ -754,6 +776,17 @@ diff --git a/lib/bcdice/game_system/LogHorizon.rb b/lib/bcdice/game_system/LogHo
  
          return "#{table_name}(#{total}#{dice_str})\n#{chosen}"
        end
+diff --git a/lib/bcdice/game_system/MagicaLogia.rb b/lib/bcdice/game_system/MagicaLogia.rb
+--- a/lib/bcdice/game_system/MagicaLogia.rb
++++ b/lib/bcdice/game_system/MagicaLogia.rb
+@@ -1,7 +1,5 @@
+ # frozen_string_literal: true
+ 
+-require "bcdice/base"
+-
+ module BCDice
+   module GameSystem
+     class MagicaLogia < Base
 diff --git a/lib/bcdice/game_system/MetalHead.rb b/lib/bcdice/game_system/MetalHead.rb
 --- a/lib/bcdice/game_system/MetalHead.rb
 +++ b/lib/bcdice/game_system/MetalHead.rb
@@ -1000,6 +1033,17 @@ diff --git a/lib/bcdice/game_system/TunnelsAndTrolls.rb b/lib/bcdice/game_system
          if level <= 0
            "失敗 ＞ 経験値#{dice_total}"
          else
+diff --git a/lib/bcdice/game_system/UnsungDuet.rb b/lib/bcdice/game_system/UnsungDuet.rb
+--- a/lib/bcdice/game_system/UnsungDuet.rb
++++ b/lib/bcdice/game_system/UnsungDuet.rb
+@@ -1,7 +1,5 @@
+ # frozen_string_literal: true
+ 
+-require "bcdice"
+-
+ module BCDice
+   module GameSystem
+     class UnsungDuet < Base
 diff --git a/lib/bcdice/game_system/VampireTheMasquerade5th.rb b/lib/bcdice/game_system/VampireTheMasquerade5th.rb
 --- a/lib/bcdice/game_system/VampireTheMasquerade5th.rb
 +++ b/lib/bcdice/game_system/VampireTheMasquerade5th.rb
@@ -1109,7 +1153,15 @@ diff --git a/lib/bcdice/game_system/YearZeroEngine.rb b/lib/bcdice/game_system/Y
 diff --git a/lib/bcdice/game_system/Yggdrasill.rb b/lib/bcdice/game_system/Yggdrasill.rb
 --- a/lib/bcdice/game_system/Yggdrasill.rb
 +++ b/lib/bcdice/game_system/Yggdrasill.rb
-@@ -198,7 +198,7 @@ module BCDice
+@@ -1,7 +1,5 @@
+ # frozen_string_literal: true
+ 
+-require "bcdice/base"
+-
+ module BCDice
+   module GameSystem
+     class Yggdrasill < Base
+@@ -198,7 +196,7 @@ module BCDice
              1
            elsif value <= 11
              dice = @randomizer.roll_once(6)


### PR DESCRIPTION
冗長な `require "bcdice"` により、i18nの展開が発生していたので該当requireを削除