### PR TITLE
LoaderのdynamicImport関数の引数をパスではなくclassNameに変更（カスタムローダーの実装を容易にするため）

### DIFF
--- a/ts/loader/dynamic_loader.ts
+++ b/ts/loader/dynamic_loader.ts
@@ -1,7 +1,7 @@
 import Loader from './loader';
 
 export default class DynamicLoader extends Loader {
-  async dynamicImport(path: string): Promise<void> {
-    await import(path);
+  async dynamicImport(className: string): Promise<void> {
+    await import(`../../lib/bcdice/game_system/${className}`);
   }
 }

--- a/ts/loader/loader.ts
+++ b/ts/loader/loader.ts
@@ -58,7 +58,7 @@ export default class Loader {
 
     await this.dynamicImport(className);
 
-    gameSystemClass = BCDice.GameSystem.$const_get<BaseClass>(className);
+    const gameSystemClass = BCDice.GameSystem.$const_get<BaseClass>(className);
     if (!gameSystemClass) throw new Error('Failed to load game system');
 
     return getGameSystemClass(gameSystemClass);

--- a/ts/loader/loader.ts
+++ b/ts/loader/loader.ts
@@ -56,16 +56,16 @@ export default class Loader {
     const className = this.getGameSystemInfo(id)?.className ?? id;
     if (!className.match(/^[A-Z]\w*$/)) throw new Error('Invalid id');
 
-    await this.dynamicImport(`../../lib/bcdice/game_system/${className}`);
+    await this.dynamicImport(className);
 
-    const gameSystemClass = BCDice.GameSystem.$const_get<BaseClass>(className);
+    gameSystemClass = BCDice.GameSystem.$const_get<BaseClass>(className);
     if (!gameSystemClass) throw new Error('Failed to load game system');
 
     return getGameSystemClass(gameSystemClass);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  dynamicImport(path: string): Promise<void> {
+  dynamicImport(className: string): Promise<void> {
     throw new Error('Not implemented');
   }
 }

--- a/ts/loader/static_loader.ts
+++ b/ts/loader/static_loader.ts
@@ -3,6 +3,6 @@ import '../../lib/bcdice/game_system';
 
 export default class StaticLoader extends Loader {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
-  async dynamicImport(path: string): Promise<void> {
+  async dynamicImport(className: string): Promise<void> {
   }
 }


### PR DESCRIPTION
特にwebpackに対応したローダーの実装を念頭に置いています