### PR TITLE
Loaderの自作に必要な関数をexportする

### DIFF
--- a/ts/loader/loader.ts
+++ b/ts/loader/loader.ts
@@ -5,7 +5,7 @@ import Result, { parseResult } from '../result';
 import GameSystemList, { GameSystemInfo } from '../../lib/bcdice/game_system_list.json';
 import GameSystemClass from '../game_system';
 
-function getGameSystemClass(gameSystemClass: BaseClass): GameSystemClass {
+export function getGameSystemClass(gameSystemClass: BaseClass): GameSystemClass {
   return class extends Base {
     static readonly ID = gameSystemClass.$const_get('ID');
     static readonly NAME = gameSystemClass.$const_get('NAME');


### PR DESCRIPTION
自作LoaderでdynamicLoadを上書きする時に、getGameSystemClassがexportされていないので外部で作成できないので、該当関数をexportしたいです

懸念点: この関数はそもそもexportするべき性質のものか？この関数はexportせずに、Loader基底クラスの方にこれを呼び出す関数を実装するべきか？