### PR TITLE
COMMAND_PATTERN の追加

### DIFF
--- a/ts/game_system.ts
+++ b/ts/game_system.ts
@@ -10,6 +10,7 @@ export default interface GameSystemClass {
   NAME: string;
   SORT_KEY: string;
   HELP_MESSAGE: string;
+  COMMAND_PATTERN: RegExp;
 
   new (command: string, internal?: BaseInstance): Base;
   eval(command: string): Result | null;

--- a/ts/game_system_commands.test.ts
+++ b/ts/game_system_commands.test.ts
@@ -34,6 +34,7 @@ Object.keys(testData).forEach(id => {
         expect(GameSystemClass.NAME).is.not.empty;
         expect(GameSystemClass.SORT_KEY).is.not.empty;
         expect(GameSystemClass.HELP_MESSAGE).is.not.empty;
+        expect(GameSystemClass.COMMAND_PATTERN).exist;
 
         switch (id) {
           case 'AddDice':

--- a/ts/internal/types/base.ts
+++ b/ts/internal/types/base.ts
@@ -9,4 +9,5 @@ export interface BaseInstance {
 export interface BaseClass extends Function, RubyObject {
   $new(command: string): BaseInstance;
   $eval(command: string): Result;
+  $command_pattern(): RegExp;
 }

--- a/ts/loader/loader.ts
+++ b/ts/loader/loader.ts
@@ -11,6 +11,7 @@ export function getGameSystemClass(gameSystemClass: BaseClass): GameSystemClass 
     static readonly NAME = gameSystemClass.$const_get('NAME');
     static readonly SORT_KEY = gameSystemClass.$const_get('SORT_KEY');
     static readonly HELP_MESSAGE = gameSystemClass.$const_get('HELP_MESSAGE');
+    static readonly COMMAND_PATTERN = gameSystemClass.$command_pattern();
 
     static eval(command: string): Result | null {
       return parseResult(gameSystemClass.$eval(command));


### PR DESCRIPTION
BCDiceで解釈できるコマンドのパターンが欲しかったので、`command_pattern` 相当のAPIを追加しました

BCDice側の `command_pattern` はクラスメソッドですが、値は変化しないようなので定数で持っています。
ref.) https://yard.bcdice.org/BCDice/Base.html#command_pattern-class_method