### PR TITLE
Rakefile: FileUtils.cp_rでBCDiceのファイルをコピーする

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -73,7 +73,7 @@ end
 
 directory 'patched'
 task copy: 'patched' do
-  sh 'cp -r BCDice/* patched'
+  cp_r Dir.glob('BCDice/*'), 'patched/'
 end
 
 task patch: [:copy] do


### PR DESCRIPTION
Discordに上がっていた、Windows等の `cp` コマンドが存在しない環境においてRakeタスクの `copy` が失敗する問題を解消しました。最後のタスク `build_game_system_list` と同様に `FileUtils` が提供するメソッドを使うことで、`cp` コマンドの有無にかかわらず `patched` ディレクトリにBCDiceのファイルをコピーできます。