### PR TITLE
Fix rounding of negative numbers

### DIFF
--- a/patch.diff
+++ b/patch.diff
@@ -10,21 +10,35 @@ diff --git a/lib/bcdice/arithmetic/node.rb b/lib/bcdice/arithmetic/node.rb
            divide_and_round(l, r, round_type)
          end
 
-@@ -103,7 +105,7 @@ module BCDice
+@@ -101,9 +103,10 @@ module BCDice
+           when RoundType::CEIL
+             (dividend.to_f / divisor).ceil
            when RoundType::ROUND
-             (dividend.to_f / divisor).round
+-            (dividend.to_f / divisor).round
++            x = dividend.to_f / divisor
++            x.negative? ? -(x.abs.round) : x.round
            else # RoundType::FLOOR
 -            dividend / divisor
 +            (dividend / divisor).floor
            end
          end
        end
-@@ -155,7 +157,7 @@ module BCDice
+@@ -138,7 +141,8 @@ module BCDice
+         # @param [Symbol] _round_type ゲームシステムの端数処理設定
+         # @return [Integer]
+         def divide_and_round(dividend, divisor, _round_type)
+-          (dividend.to_f / divisor).round
++          x = dividend.to_f / divisor
++          x.negative? ? -(x.abs.round) : x.round
+         end
+       end
+
+@@ -155,7 +159,7 @@ module BCDice
          # @param [Symbol] _round_type ゲームシステムの端数処理設定
          # @return [Integer]
          def divide_and_round(dividend, divisor, _round_type)
 -          dividend / divisor
-+          (dividend / divisor).to_i
++          (dividend / divisor).floor
          end
        end
 
@@ -70,25 +84,39 @@ diff --git a/lib/bcdice/common_command/add_dice/node.rb b/lib/bcdice/common_comm
            end
 
            # 除算および端数処理を行う
-@@ -273,7 +273,7 @@ module BCDice
+@@ -271,9 +271,10 @@ module BCDice
+             when RoundType::CEIL
+               (dividend.to_f / divisor).ceil
              when RoundType::ROUND
-               (dividend.to_f / divisor).round
+-              (dividend.to_f / divisor).round
++              x = dividend.to_f / divisor
++              x.negative? ? -(x.abs.round) : x.round
              else # RoundType::FLOOR
 -              dividend / divisor
 +              (dividend / divisor).floor
              end
            end
          end
-@@ -319,7 +319,7 @@ module BCDice
+@@ -304,7 +305,8 @@ module BCDice
+           # @param (see DivideWithGameSystemDefault#divide_and_round)
+           # @return [Integer]
+           def divide_and_round(dividend, divisor, _round_type)
+-            (dividend.to_f / divisor).round
++            x = dividend.to_f / divisor
++            x.negative? ? -(x.abs.round) : x.round
+           end
+         end
+
+@@ -319,7 +321,7 @@ module BCDice
            # @param (see DivideWithGameSystemDefault#divide_and_round)
            # @return [Integer]
            def divide_and_round(dividend, divisor, _round_type)
 -            dividend / divisor
-+            (dividend / divisor).to_i
++            (dividend / divisor).floor
            end
          end
 
-@@ -342,7 +342,7 @@ module BCDice
+@@ -342,7 +344,7 @@ module BCDice
            # @param [Randomizer] randomizer ランダマイザ
            # @return [Integer] 評価結果
            def eval(game_system, randomizer)
@@ -97,7 +125,7 @@ diff --git a/lib/bcdice/common_command/add_dice/node.rb b/lib/bcdice/common_comm
            end
 
            # @return [Boolean]
-@@ -398,7 +398,7 @@ module BCDice
+@@ -398,7 +400,7 @@ module BCDice
              total = dice_list.sum()
              @text = "#{total}[#{dice_list.join(',')}]"
 
@@ -106,7 +134,7 @@ diff --git a/lib/bcdice/common_command/add_dice/node.rb b/lib/bcdice/common_comm
            end
 
            # @return [Boolean]
-@@ -525,7 +525,7 @@ module BCDice
+@@ -525,7 +527,7 @@ module BCDice
 
              @text = "#{total}[#{sorted_values.join(',')}]"
 
@@ -115,7 +143,7 @@ diff --git a/lib/bcdice/common_command/add_dice/node.rb b/lib/bcdice/common_comm
            end
 
            # @return [Boolean]
-@@ -566,7 +566,7 @@ module BCDice
+@@ -566,7 +568,7 @@ module BCDice
            # @param randomizer [Randomizer]
            # @return [integer]
            def eval(game_system, randomizer)
@@ -124,7 +152,7 @@ diff --git a/lib/bcdice/common_command/add_dice/node.rb b/lib/bcdice/common_comm
            end
 
            # @return [Boolean]
-@@ -599,7 +599,7 @@ module BCDice
+@@ -599,7 +601,7 @@ module BCDice
            # ノードを初期化する
            # @param [Integer] literal 値
            def initialize(literal)
@@ -133,7 +161,7 @@ diff --git a/lib/bcdice/common_command/add_dice/node.rb b/lib/bcdice/common_comm
            end
 
            # 符号を反転した結果の数値ノードを返す
-@@ -611,7 +611,7 @@ module BCDice
+@@ -611,7 +613,7 @@ module BCDice
            # ノードを評価する
            # @return [Integer] 格納している値
            def eval(_game_system, _randomizer)
@@ -1256,7 +1284,7 @@ diff --git a/lib/bcdice/user_defined_dice_table.rb b/lib/bcdice/user_defined_dic
 diff --git a/test/data/calc.toml b/test/data/calc.toml
 --- a/test/data/calc.toml
 +++ b/test/data/calc.toml
-@@ -256,3 +256,27 @@ input = "sc1+4*3/2"
+@@ -256,3 +256,57 @@ input = "sc1+4*3/2"
  output = "c(1+4*3/2) ＞ 7"
  secret = true
  rands = []
@@ -1284,3 +1312,33 @@ diff --git a/test/data/calc.toml b/test/data/calc.toml
 +input = "c((1+2)/2F) 切り捨て"
 +output = "c((1+2)/2F) ＞ 1"
 +rands = [{ sides = 1, value = 1 }]
++
++[[ test ]]
++game_system = "DiceBot"
++input = "C(-5/10F)"
++output = "c(-5/10F) ＞ -1"
++rands = []
++
++[[ test ]]
++game_system = "DiceBot"
++input = "C(-5/10C)"
++output = "c(-5/10C) ＞ 0"
++rands = []
++
++[[ test ]]
++game_system = "DiceBot"
++input = "C(-6/10R)"
++output = "c(-6/10R) ＞ -1"
++rands = []
++
++[[ test ]]
++game_system = "DiceBot"
++input = "C(-5/10R)"
++output = "c(-5/10R) ＞ -1"
++rands = []
++
++[[ test ]]
++game_system = "DiceBot"
++input = "C(-4/10R)"
++output = "c(-4/10R) ＞ 0"
++rands = []


### PR DESCRIPTION
負数の除算において、RoundとFloorの処理がRubyの挙動と異なっている問題を修正した。

## Roundについて

JavaScriptとRubyで負数における`Math.round()` と `Floor#round` の挙動が異なり、Opalではその違いを吸収していない。

Xを整数とした時に、JavaScriptでは符号に関係なく、 X+0.5 > X >= X-0.5 の範囲がXに丸められる。RubyはXの絶対値について X.abs+0.5 > X.abs >= X.abs-0.5 の範囲でXに丸める。

今回の変更で、round処理時には値が負数か確認し、絶対値を使って計算するようにした。

### JavaScript
```js
> Math.round(-0.4)
-0
> Math.round(-0.5)
-0
> Math.round(-0.6)
-1
```
[Math.round()](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Math/round)

### Ruby
```ruby
irb(main):002:0> -0.4.round
=> 0
irb(main):003:0> -0.5.round
=> -1
irb(main):004:0> -0.6.round
=> -1
```

[Float#round](https://docs.ruby-lang.org/ja/latest/method/Float/i/round.html)

## Floorについて

除算の結果を整数にするために `Number#to_i` が使われていたが、`Number#to_i` と `Float#floor` は負数において挙動が異なる。 `#to_i`は単に小数点以下を0にするが、`Float#floor` は自身と等しいかより小さな整数のうち最大のものを返す。Rubyでは整数の除算は、`Float#floor` の挙動となるため、動作が合致していなかった。

```ruby
irb(main):005:0> -0.5.to_i
=> 0
irb(main):006:0> -0.5.floor
=> -1
irb(main):007:0> -1/2
=> -1
```

今回の変更で、四則演算の端数処理で `#floor` を使うようにする。