### PR TITLE
:green_heart: Fix push error on auto-update

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -24,5 +24,5 @@ jobs:
     - run: |
         git add patch.diff BCDice Gemfile.lock
         git commit -m ":heavy_plus_sign: Update BCDice to $(git -C BCDice rev-parse --short HEAD)"
-        git push --force
+        git push --force origin bcdice-auto-update
       continue-on-error: true


### PR DESCRIPTION
auto-updateのpushに失敗しているのを修正しています。

https://github.com/bcdice/bcdice-js/runs/6640213907?check_suite_focus=true#step:5:14

```
Run git add patch.diff BCDice Gemfile.lock
  git add patch.diff BCDice Gemfile.lock
  git commit -m ":heavy_plus_sign: Update BCDice to $(git -C BCDice rev-parse --short HEAD)"
  git push --force
  shell: /usr/bin/bash -e {0}
[bcdice-auto-update 1adffe4] :heavy_plus_sign: Update BCDice to 84300e5f
 [2](https://github.com/bcdice/bcdice-js/runs/6640213907?check_suite_focus=true#step:5:2) files changed, 1[4](https://github.com/bcdice/bcdice-js/runs/6640213907?check_suite_focus=true#step:5:4)1 insertions(+), 141 deletions(-)
fatal: The current branch bcdice-auto-update has no upstream branch.
To push the current branch and set the remote as upstream, use

    git push --set-upstream origin bcdice-auto-update
```