### PR TITLE
i18nの情報を実行時に動的インポートする

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -129,11 +129,10 @@ task build_i18n_json: 'lib/bcdice/i18n' do
   path_from = Pathname('patched/i18n')
   Dir['patched/i18n/**/*.yml'].each do |path|
     relative_path = Pathname(path).relative_path_from(path_from).to_s
-    next unless 1 < relative_path.split('/').length
+    next unless relative_path.split('/').length > 1
 
     i18n = YAML.load_file(path)
     file_name = File.basename(relative_path.gsub('/', '.'), '.*')
-    locale = File.basename(relative_path, '.*')
     File.write "lib/bcdice/i18n/#{file_name}.json", JSON.dump(i18n)
     puts "bcdice/i18n/#{file_name}.json"
   end
@@ -148,7 +147,8 @@ task build_i18n_list: 'lib/bcdice' do
       locales.push(File.basename(path, '.*'))
     end
     name = File.split(game_path.gsub('patched/i18n', '')).last
-    next unless 1 < name.length
+    next unless name.length > 1
+
     ids.push({ baseClassName: name, locales: locales })
   end
   File.write 'lib/bcdice/i18n_list.json', JSON.dump({ i18nList: ids })

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,8 @@ task build: %i[
   build_core
   build_game_system
   build_i18n
+  build_i18n_json
+  build_i18n_list
   build_test
   build_game_system_list
 ]
@@ -109,17 +111,50 @@ task build_game_system: 'lib/bcdice/game_system' do
   decleation('bcdice/game_system/index')
 end
 
-directory 'lib/bcdice'
-task build_i18n: 'lib/bcdice' do
+directory 'lib/bcdice/i18n'
+task build_i18n: 'lib/bcdice/i18n' do
   i18n = {}
-  Dir['patched/i18n/**/*.yml'].each do |path|
+  Dir['patched/i18n/*.yml'].each do |path|
     i18n = i18n.merge(YAML.load_file(path)) do |_key, oldval, newval|
       oldval.merge(newval)
     end
   end
 
-  File.write 'lib/bcdice/i18n.yml', YAML.dump(i18n)
-  File.write 'lib/bcdice/i18n.json', JSON.dump(i18n)
+  File.write 'lib/bcdice/i18n/i18n.yml', YAML.dump(i18n)
+  File.write 'lib/bcdice/i18n/i18n.json', JSON.dump(i18n)
+end
+
+directory 'lib/bcdice/i18n'
+task build_i18n_json: 'lib/bcdice/i18n' do
+  path_from = Pathname('patched/i18n')
+  Dir['patched/i18n/**/*.yml'].each do |path|
+    relative_path = Pathname(path).relative_path_from(path_from).to_s
+    next unless 1 < relative_path.split('/').length
+
+    i18n = YAML.load_file(path)
+    file_name = File.basename(relative_path.gsub('/', '.'), '.*')
+    locale = File.basename(relative_path, '.*')
+    File.write "lib/bcdice/i18n/#{file_name}.json", JSON.dump(i18n)
+    puts "bcdice/i18n/#{file_name}.json"
+  end
+end
+
+directory 'lib/bcdice'
+task build_i18n_list: 'lib/bcdice' do
+  ids = []
+  Dir['patched/i18n/**/'].each do |game_path|
+    locales = []
+    Dir["#{game_path}*.yml"].each do |path|
+      locales.push(File.basename(path, '.*'))
+    end
+    name = File.split(game_path.gsub('patched/i18n', '')).last
+    next unless 1 < name.length
+    ids.push({ baseClassName: name, locales: locales })
+  end
+  File.write 'lib/bcdice/i18n_list.json', JSON.dump({ i18nList: ids })
+
+  puts 'bcdice/i18n_list.json.d.ts'
+  FileUtils.copy 'ts/bcdice/i18n_list.json.d.ts', 'lib/bcdice/i18n_list.json.d.ts'
 end
 
 directory 'lib/bcdice'
@@ -145,7 +180,8 @@ task build_game_system_list: [:patch, 'lib/bcdice'] do
       id: game_system_class::ID,
       name: game_system_class::NAME,
       className: game_system_class.name.gsub(/^.*::/, ''),
-      sortKey: game_system_class::SORT_KEY
+      sortKey: game_system_class::SORT_KEY,
+      locale: game_system_class.new('none').instance_variable_get('@locale')
     }
   end
 

--- a/ruby/emurators/i18n.rb
+++ b/ruby/emurators/i18n.rb
@@ -38,6 +38,11 @@ module I18n
       end
     end
 
+    # only used to i18n dynamic import test
+    def clear_translate_table
+      @@table = nil
+    end
+
     def translate(key, locale: nil, **options)
       load_default_translation
 

--- a/ruby/emurators/i18n.rb
+++ b/ruby/emurators/i18n.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require "json"
+
+require 'json'
 
 # Simple emulator
 module I18n
@@ -26,7 +27,7 @@ module I18n
       return unless @@table.nil?
 
       @@table = {}
-      load_translation(`JSON.stringify(require('./i18n/i18n.json'))`);
+      load_translation(`JSON.stringify(require('./i18n/i18n.json'))`)
     end
 
     def load_translation(json)

--- a/ts/bcdice/game_system_list.json.d.ts
+++ b/ts/bcdice/game_system_list.json.d.ts
@@ -3,6 +3,7 @@ export interface GameSystemInfo {
   className: string;
   name: string;
   sortKey: string;
+  locale: string;
 }
 
 export declare const gameSystems: GameSystemInfo[];

--- a/ts/bcdice/i18n_list.json.d.ts
+++ b/ts/bcdice/i18n_list.json.d.ts
@@ -1,0 +1,6 @@
+export interface I18nInfo {
+  baseClassName: string;
+  locales: string[];
+}
+
+export declare const i18nList: I18nInfo[];

--- a/ts/game_system_commands.test.ts
+++ b/ts/game_system_commands.test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { expect } from 'chai';
 import DynamicLoader from './loader/dynamic_loader';
 import { mockRandomizer } from './test/randomizer';
+import { I18n } from './internal';
 
 type TestDataType = Record<string, {
   test: {
@@ -37,6 +38,7 @@ Object.keys(testData).forEach(id => {
         fumble: data.fumble ?? false,
       };
 
+      I18n.$clear_translate_table();
       const loader = new DynamicLoader();
 
       it('should be valid GameSystem', async () => {

--- a/ts/internal/index.ts
+++ b/ts/internal/index.ts
@@ -17,6 +17,7 @@ export interface BCDiceModule extends Module {
 export interface I18nModule extends Module {
   $load_translation(json: any): void;
   $default_locale(): string;
+  $clear_translate_table(): void;
 }
 
 export const BCDice = Opal_.module<BCDiceModule>(null, 'BCDice');

--- a/ts/internal/index.ts
+++ b/ts/internal/index.ts
@@ -15,7 +15,7 @@ export interface BCDiceModule extends Module {
 }
 
 export interface I18nModule extends Module {
-  $load_translation(json: any): void;
+  $load_translation(json: string): void;
   $default_locale(): string;
   $clear_translate_table(): void;
 }

--- a/ts/internal/index.ts
+++ b/ts/internal/index.ts
@@ -14,5 +14,11 @@ export interface BCDiceModule extends Module {
   VERSION: string;
 }
 
+export interface I18nModule extends Module {
+  $load_translation(json: any): void;
+  $default_locale(): string;
+}
+
 export const BCDice = Opal_.module<BCDiceModule>(null, 'BCDice');
+export const I18n = Opal_.module<I18nModule>(null, 'I18n')
 export { default as Opal } from './opal';

--- a/ts/loader/dynamic_loader.ts
+++ b/ts/loader/dynamic_loader.ts
@@ -1,6 +1,10 @@
-import Loader from './loader';
+import Loader, { I18nJsonObject } from './loader';
 
 export default class DynamicLoader extends Loader {
+  async dynamicImportI18n(baseClassName: string, locale: string): Promise<I18nJsonObject> {
+    return (await import(`../../lib/bcdice/i18n/${baseClassName}.${locale}.json`)).default as I18nJsonObject;
+  }
+
   async dynamicImport(className: string): Promise<void> {
     await import(`../../lib/bcdice/game_system/${className}`);
   }

--- a/ts/loader/loader.test.ts
+++ b/ts/loader/loader.test.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { I18n } from '../internal';
 import Loader from './loader';
 
 const loaders: [string, string, boolean][] = [
@@ -9,6 +10,7 @@ const loaders: [string, string, boolean][] = [
 loaders.forEach(([path, title /*, dynamic */ ]) => {
   describe(title, () => {
 
+    I18n.$clear_translate_table();
     let loader: Loader;
     it('can be imported', async () => {
       loader = new (await import(path)).default();

--- a/ts/loader/loader.ts
+++ b/ts/loader/loader.ts
@@ -88,6 +88,7 @@ export default class Loader {
     return getGameSystemClass(gameSystemClass);
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   dynamicImportI18n(baseClassName: string, locale: string): Promise<I18nJsonObject> {
     throw new Error('Not implemented');
   }

--- a/ts/loader/loader.ts
+++ b/ts/loader/loader.ts
@@ -1,9 +1,12 @@
 import Base from '../base';
 import { BaseClass, BaseInstance } from '../internal/types/base';
-import { BCDice } from '../internal';
+import { BCDice, I18n } from '../internal';
 import Result, { parseResult } from '../result';
 import GameSystemList, { GameSystemInfo } from '../../lib/bcdice/game_system_list.json';
+import I18nList, { I18nInfo } from '../../lib/bcdice/i18n_list.json';
 import GameSystemClass from '../game_system';
+
+export type I18nJsonObject = Record<string, unknown>;
 
 export function getGameSystemClass(gameSystemClass: BaseClass): GameSystemClass {
   return class extends Base {
@@ -43,6 +46,12 @@ export default class Loader {
     return gameSystem;
   }
 
+  getI18nInfo(className: string): I18nInfo | null {
+    const baseClassName = className.replace(/_[^0-9].*$/g, '');
+    const i18n = this.listAvailabletI18nInfoList().find(i18n => i18n.baseClassName === baseClassName) ?? null;
+    return i18n;
+  }
+
   listLoadedGameSystems(): GameSystemClass[] {
     return BCDice.GameSystem
       ?.$constants()
@@ -53,9 +62,23 @@ export default class Loader {
     return GameSystemList.gameSystems;
   }
 
+  listAvailabletI18nInfoList(): I18nInfo[] {
+    return I18nList.i18nList;
+  }
+
   async dynamicLoad(id: string): Promise<GameSystemClass> {
-    const className = this.getGameSystemInfo(id)?.className ?? id;
+    const info = this.getGameSystemInfo(id);
+    const className = info?.className ?? id;
     if (!className.match(/^[A-Z]\w*$/)) throw new Error('Invalid id');
+
+    const i18nInfo = this.getI18nInfo(className);
+    if (i18nInfo) {
+      const locales = i18nInfo.locales.filter(locale => locale === info.locale || locale === I18n.$default_locale());
+      for (const locale of locales) {
+        const json = JSON.stringify(await this.dynamicImportI18n(i18nInfo.baseClassName, locale));
+        I18n.$load_translation(json);
+      };
+    }
 
     await this.dynamicImport(className);
 
@@ -63,6 +86,10 @@ export default class Loader {
     if (!gameSystemClass) throw new Error('Failed to load game system');
 
     return getGameSystemClass(gameSystemClass);
+  }
+
+  dynamicImportI18n(baseClassName: string, locale: string): Promise<I18nJsonObject> {
+    throw new Error('Not implemented');
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/ts/loader/static_loader.ts
+++ b/ts/loader/static_loader.ts
@@ -1,8 +1,26 @@
-import Loader from './loader';
-import '../../lib/bcdice/game_system';
+import Loader, { I18nJsonObject } from './loader';
+import I18nList from '../../lib/bcdice/i18n_list.json';
+import { I18n } from '../internal';
+
+staticImport();
 
 export default class StaticLoader extends Loader {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
+  async dynamicImportI18n(baseClassName: string, locale: string): Promise<I18nJsonObject> {
+    return {};
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-empty-function
   async dynamicImport(className: string): Promise<void> {
   }
+}
+
+function staticImport() {
+  I18nList.i18nList.forEach(I18nInfo => {
+    I18nInfo.locales.forEach(locale => {
+      const json = JSON.stringify(require(`../../lib/bcdice/i18n/${I18nInfo.baseClassName}.${locale}.json`));
+      I18n.$load_translation(json);
+    });
+  });
+  require('../../lib/bcdice/game_system');
 }

--- a/ts/loader/static_loader.ts
+++ b/ts/loader/static_loader.ts
@@ -1,6 +1,6 @@
-import Loader, { I18nJsonObject } from './loader';
 import I18nList from '../../lib/bcdice/i18n_list.json';
 import { I18n } from '../internal';
+import Loader, { I18nJsonObject } from './loader';
 
 staticImport();
 
@@ -18,6 +18,7 @@ export default class StaticLoader extends Loader {
 function staticImport() {
   I18nList.i18nList.forEach(I18nInfo => {
     I18nInfo.locales.forEach(locale => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
       const json = JSON.stringify(require(`../../lib/bcdice/i18n/${I18nInfo.baseClassName}.${locale}.json`));
       I18n.$load_translation(json);
     });


### PR DESCRIPTION
## 概要
多言語翻訳ファイル（`ja_jp.yml`, `ko_kr.yml`, etc.）を実行時に動的インポートする機能を追加しました。

## 目的
bcdice-jsは各ダイスボットを**動的インポート**する機能を持っていますが、i18n情報については初期ロード時に全ダイスボットのi18n情報を一括で**静的インポート**する仕様になっています。

この仕様は処理としては問題ないものの、bcdice-jsをwebpack等でバンドルした際に「バンドルサイズが不必要に肥大化する」という課題を生み出します。

例えば、bcdice-jsをwebpackのchunk（jsファイル）として出力した場合、bcdice-js本体のchunkは約4.0MBのjsを生成しますが、その内の約1.5MBはi18nの翻訳文字列データです。
多くの場合、一度に利用するダイスボットは1つのため、1.5MBの翻訳文字列の大部分を不要なデータとして初期ロードしていることになります。

このPRでは、i18n情報を動的インポートすることによって、bcdice-jsをバンドルした際にi18nファイルを個別のchunkとして分割、jsのロードを効率化できるように変更します。

## 変更内容
主な変更点は以下の通りです。
- 各ダイスボットのi18nファイルを個別出力 (ex. `lib/i18n/Amadeus.ja_jp.json`)
- i18n情報を参照する為の`i18n_list.json`を生成
- 各ダイスボットの翻訳言語を識別する為に`game_system_list.json`に`locale`キーを追加
- `Loader`クラスに`dynamicImportI18n()`を定義
- `Loader`の`dynamicLoad()`実行時にダイスボットのi18n情報を動的インポート
- ダイスボットに依存しないi18n情報は静的インポート

## 影響範囲
`DynamicLoader`や`StaticLoader`をそのまま利用する分には互換性に関する影響はない筈です。
テストも問題なくパスします。

しかし、`Loader`を継承してカスタムローダーを実装している場合は（若干の）破壊的変更が発生します。
`Loader`クラスの`dynamicImportI18n()`は`dynamicImport()`の実装に習って`throw new Error('Not implemented')`しているため、`Loader`を継承した既存のカスタムローダーは、そのままだと`dynamicLoad()`実行時にエラーになってしまいます。

後方互換性を考慮する場合、`Loader`の`dynamicImportI18n()`は空実装の方が望ましいかもしれません。