### PR TITLE
クラス継承を使用しているダイスボットでは全ての継承元クラスのi18n情報を動的インポートする

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -191,6 +191,7 @@ task build_game_system_list: [:patch, 'lib/bcdice'] do
       id: game_system_class::ID,
       name: game_system_class::NAME,
       className: game_system_class.name.gsub(/^.*::/, ''),
+      superClassName: game_system_class.superclass.name.gsub(/^.*::/, ''),
       sortKey: game_system_class::SORT_KEY,
       locale: game_system_class.new('none').instance_variable_get('@locale')
     }

--- a/ts/bcdice/game_system_list.json.d.ts
+++ b/ts/bcdice/game_system_list.json.d.ts
@@ -3,6 +3,7 @@ export interface GameSystemInfo {
   className: string;
   name: string;
   sortKey: string;
+  superClassName: string;
   locale: string;
 }
 

--- a/ts/game_system_commands.test.ts
+++ b/ts/game_system_commands.test.ts
@@ -38,10 +38,10 @@ Object.keys(testData).forEach(id => {
         fumble: data.fumble ?? false,
       };
 
-      I18n.$clear_translate_table();
       const loader = new DynamicLoader();
 
       it('should be valid GameSystem', async () => {
+        I18n.$clear_translate_table();
         const loader = new DynamicLoader();
         const GameSystemClass = await loader.dynamicLoad(test.game_system);
 
@@ -74,6 +74,7 @@ Object.keys(testData).forEach(id => {
       });
 
       it(`evals ${test.input} to ${test.output}`, async () => {
+        I18n.$clear_translate_table();
         const GameSystemClass = await loader.dynamicLoad(test.game_system);
         const gameSystem = new GameSystemClass(test.input);
 


### PR DESCRIPTION
## 概要
[CIのエラー](https://github.com/bcdice/bcdice-js/actions/runs/3248320346/jobs/5330385728)で気付いたバグの修正です。
あるダイスボットが別のダイスボットと継承関係を持っている場合、全ての継承元クラスのi18nファイルを動的インポートする必要があります。

## バグ
#53 のコードにはバグがありました。
具体的な再現例としては`SwordWorld2.5`を動的インポートする場合が挙げられます。

初期状態から`SwordWorld2.5`**のみ**を動的インポートした場合、#53 のコードでは`SwordWorld2.5`のi18nファイルだけがインポートされた状態となります。
この状態で`SwordWorld2.5`の継承元クラスである`SwordWorld`や`SwordWorld2.0`の機能を使用すると、`SwordWorld`と`SwordWorld2.0`のi18n情報不足によってエラーになります。

## CIのエラー
#53 でローカル環境のテストがパスしていたのは、`I18n.$clear_translate_table()`によるi18nリセットのタイミングが適切ではなく、`SwordWorld`→`SwordWorld2.0`→`SwordWorld2.5`という"安全な順番"で動的インポート＆テストが行われていた為と考えています。

GitHubのCIでエラーが表面化した理由は、推測ですが、async/awaitのタイミング揺らぎでi18n情報リセットのタイミングがブレたのかなと考えています。（曖昧）
テスト結果としてはCIの挙動とエラーが正しい筈です。

## 変更内容
- 各ダイスボットの継承関係を識別する為に`game_system_list.json`に`superClassName`キーを追加
- `Loader`クラスの`getI18nInfos()`で対象ダイスボットの継承元クラスを含めた`i18nInfo[]`を取得
- `Loader`の`dynamicLoad()`実行時に継承元クラスのi18nファイルも動的インポート
- テストにおいて`game_system_commands.test.ts`の`I18n.$clear_translate_table()`実行タイミングを修正

クラス継承があり、なおかつi18nを使用するダイスボットは現状では`SwordWorld`系統のみです。
しかし、将来的に追加されるダイスボットが`SwordWorld`系統と同様または亜種的なクラス継承関係を持つ場合が想定されます。

このPRではそういったクラス継承が存在する場合のi18nファイル検索も想定して`game_system_list.json`に`superClassName`キーを追加しています。

## 影響範囲
影響範囲は #53 のバグ修正のみです。