### PR TITLE
ci: 🧪 update CI matrix for ruby 3.2 and node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version:
@@ -24,7 +23,7 @@ jobs:
         registry-url: https://registry.npmjs.org/
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.0
+        ruby-version: 3.2
         bundler-cache: true
     - run: npm ci
     - run: npm run clean


### PR DESCRIPTION
CIのRubyを3.2に更新