### PR TITLE
fix: fix eslint config of global ignore

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,7 +13,9 @@ module.exports = [
       "**/*.map",
       "lib/bcdice/opal.js",
       "lib/bcdice/opal-parser.js",
-    ],
+    ]
+  },
+  {
     linterOptions: {
       reportUnusedDisableDirectives: "off",
     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "example:ts-basic": "cd examples/ts && ts-node ./basic",
     "example:ts-user_defined_dice_table": "cd examples/ts && ts-node ./user_defined_dice_table",
     "lint": "run-s lint:*",
-    "lint:eslint": "eslint ts/**/*.ts examples/**/*.ts",
+    "lint:eslint": "eslint --no-warn-ignored ts/**/*.ts examples/**/*.ts",
     "lint:rubocop": "bundle exec rubocop ruby Rakefile",
     "lint:lib": "eslint --no-error-on-unmatched-pattern --ext .js lib",
     "test": "cd ts && mocha -r ts-node/register -r source-map-support/register --reporter dot --timeout 5000 --extension ts \"**/*.test.ts\""


### PR DESCRIPTION
ESLintでの検査から除外するファイルが期待通りに認識されていなかった問題を修正します。

`eslint.config.js` でグローバルに `ignores` を指定するには `ignores` 単独のオブジェクトで記述しなければならないようです。現状では `ignores` と `linterOptions` が同じところで記述されてしまっていたので、分割しました。

また、 `npm run lint:eslint` で指定したファイル一覧に `ignores` のファイルが含まれることで `warn` が発生していたため、これを抑制する `--no-warn-ignored` オブションで起動するように変更しました。

## 参考
[Globally ignoring files with ignores - ESLint](https://eslint.org/docs/v9.x/use/configure/configuration-files#globally-ignoring-files-with-ignores)
> When ignores is used without any other keys (besides name) in the configuration object, then the patterns act as global ignores. This means they apply to every configuration object (not only to the configuration object in which it is defined). Global ignores allows you not to have to copy and keep the ignores property synchronized in more than one configuration object.