### PR TITLE
ci: Move to Trusted Publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,3 @@ jobs:
     - run: npm run lint
     - run: npm test
     - run: npm run example
-
-    - run: npm publish
-      if: ${{ matrix.node-version == 'current' && startsWith(github.ref, 'refs/tags/v') }}
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish Package
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/setup-node@v3
+        with:
+          node-version: current
+          cache: npm
+          registry-url: https://registry.npmjs.org/
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.2
+          bundler-cache: true
+      - run: npm ci
+      - run: npm run clean
+      - run: BUNDLE_PATH="$(pwd)/vendor/bundle" npm run build
+      - run: npm run lint
+      - run: npm test
+      - run: npm run example
+      - run: npm publish


### PR DESCRIPTION
従来のパッケージリリースで用いていた [Personal access token が廃止](https://github.blog/changelog/2025-12-09-npm-classic-tokens-revoked-session-based-auth-and-cli-token-management-now-available/)となったため、[Trusted publishing](https://docs.npmjs.com/trusted-publishers) を使った方法に移行します。

## 変更点
- 発行される認証情報の公開範囲を最小限にするため、リリース処理を `ci.yml` から `publish.yml` に移行
- `publish.yml` で Trusted publishing のために id token の利用を許可

## 備考
npmjs.com 側の設定は変更済みです。